### PR TITLE
Add timeframe charts and PST predictions

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
     ];
 
     const charts = {};
-    const history = {};
+    const rangesData = {};
 
     async function fetchFearGreed() {
       try {
@@ -37,19 +37,31 @@
       }
     }
 
+    async function fetchHistoricalData(id, days) {
+      const url = `https://api.coingecko.com/api/v3/coins/${id}/market_chart?vs_currency=usd&days=${days}`;
+      const res = await fetch(url);
+      const data = await res.json();
+      return data.prices.map(p => p[1]);
+    }
+
     function generatePredictions(current) {
       const predictions = [];
       let price = parseFloat(current);
-      for (let i = 0; i < 24; i++) {
+      const now = new Date();
+      for (let i = 1; i <= 24; i++) {
         price = price * (1 + (Math.random() - 0.5) / 50); // +/-1%
-        predictions.push(price);
+        const t = new Date(now.getTime() + i * 3600 * 1000);
+        predictions.push({
+          time: t.toLocaleString('en-US', { timeZone: 'America/Los_Angeles', hour: 'numeric', hour12: false }),
+          price
+        });
       }
       return predictions;
     }
 
     function advise(current, predictions) {
       const c = parseFloat(current);
-      const next = predictions[0];
+      const next = predictions[0].price;
       if (next > c * 1.01) return 'Buy';
       if (next < c * 0.99) return 'Sell';
       return 'Hold';
@@ -61,6 +73,16 @@
       const res = await fetch(url);
       const data = await res.json();
       const fng = await fetchFearGreed();
+
+      for (const coin of coins) {
+        const [hour, week, all] = await Promise.all([
+          fetchHistoricalData(coin.id, 1),
+          fetchHistoricalData(coin.id, 7),
+          fetchHistoricalData(coin.id, 'max')
+        ]);
+        rangesData[coin.id] = { hour, week, all };
+      }
+
       render(data, fng);
     }
 
@@ -75,7 +97,7 @@
         const predictions = generatePredictions(price);
         const advice = advise(price, predictions);
         const rows = predictions
-          .map((p, i) => `<tr><td class="pr-2">${i + 1}h</td><td>$${p.toFixed(4)}</td></tr>`) 
+          .map(p => `<tr><td class="pr-2">${p.time}</td><td>$${p.price.toFixed(4)}</td></tr>`)
           .join('');
         card.innerHTML = `
           <h2 class="text-xl font-semibold mb-2 flex items-center">
@@ -87,30 +109,33 @@
           <p class="${change >= 0 ? 'text-green-600' : 'text-red-600'}">24h Change: ${change}%</p>
           <p>Fear &amp; Greed Index: ${fearGreed}</p>
           <p>Advice: <span class="font-semibold">${advice}</span></p>
+          <select id="range-${info.id}" class="mb-2 border rounded p-1">
+            <option value="hour">Hourly</option>
+            <option value="week">Weekly</option>
+            <option value="all">All Time</option>
+          </select>
           <canvas id="chart-${info.id}" height="100"></canvas>
           <div class="overflow-y-auto h-32 mt-2">
             <table class="text-sm w-full">
-              <thead><tr><th class="text-left">Hr</th><th class="text-left">Predicted</th></tr></thead>
+              <thead><tr><th class="text-left">PST Hr</th><th class="text-left">Predicted</th></tr></thead>
               <tbody>${rows}</tbody>
             </table>
           </div>
         `;
         container.appendChild(card);
 
-        if (!history[info.id]) history[info.id] = [];
-        history[info.id].push(info.current_price);
-        if (history[info.id].length > 60) history[info.id].shift();
-
+        const rangeSelect = document.getElementById(`range-${info.id}`);
+        const ctx = document.getElementById(`chart-${info.id}`).getContext('2d');
+        let dataset = rangesData[info.id][rangeSelect.value];
         let chart = charts[info.id];
         if (!chart) {
-          const ctx = document.getElementById(`chart-${info.id}`).getContext('2d');
           chart = charts[info.id] = new Chart(ctx, {
             type: 'line',
             data: {
-              labels: history[info.id].map((_, i) => i),
+              labels: dataset.map((_, i) => i),
               datasets: [{
-                label: 'Live Price',
-                data: history[info.id],
+                label: 'Price',
+                data: dataset,
                 fill: false,
                 borderColor: 'rgb(75, 192, 192)',
                 tension: 0.1
@@ -119,10 +144,17 @@
             options: { animation: false, scales: { x: { display: false } } }
           });
         } else {
-          chart.data.labels = history[info.id].map((_, i) => i);
-          chart.data.datasets[0].data = history[info.id];
+          chart.data.labels = dataset.map((_, i) => i);
+          chart.data.datasets[0].data = dataset;
           chart.update();
         }
+
+        rangeSelect.addEventListener('change', () => {
+          dataset = rangesData[info.id][rangeSelect.value];
+          chart.data.labels = dataset.map((_, i) => i);
+          chart.data.datasets[0].data = dataset;
+          chart.update();
+        });
       });
     }
 


### PR DESCRIPTION
## Summary
- add historical API calls for hourly, weekly and all-time price charts
- add timeframe dropdown to switch between hourly, weekly and all-time charts
- generate prediction timestamps in Pacific Standard Time

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6887e5e334c08326b04187ed3a1c0e56