### PR TITLE
Fix refresh issue by destroying old charts

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,6 +88,9 @@
 
     function render(data, fearGreed) {
       const container = document.getElementById('tracker');
+      // Destroy existing charts to avoid referencing removed canvases
+      Object.values(charts).forEach(c => c.destroy());
+      for (const key in charts) delete charts[key];
       container.innerHTML = '';
       data.forEach(info => {
         const card = document.createElement('div');


### PR DESCRIPTION
## Summary
- clear old Chart.js instances before re-rendering dashboard

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887e72008948326badbe671b9de382c